### PR TITLE
'Forward' composition in haskell

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A collection of operators and other things I forget when going between Elm and H
 | <\|                                             | $                                 |                                                                                      |
 | \|>                                             | &                                 |                                                                                      |
 | <<                                              | .                                 |                                                                                      |
-| >>                                              |                                   | nothing 😢                                                                           |
+| >>                                              |                                   | .>                                                                           |
 |                                                 |                                   |                                                                                      |
 | ++                                              | <>                                |                                                                                      |
 | Type.andMap                                     | <\*>                              | `andMap :: f (a -> b) -> f a -> f b`                                                 |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A collection of operators and other things I forget when going between Elm and H
 | <\|                                             | $                                 |                                                                                      |
 | \|>                                             | &                                 |                                                                                      |
 | <<                                              | .                                 |                                                                                      |
-| >>                                              |                                   | .>                                                                           |
+| >>                                              | .>                                | requires the [flow](https://hackage.haskell.org/package/flow) package                |
 |                                                 |                                   |                                                                                      |
 | ++                                              | <>                                |                                                                                      |
 | Type.andMap                                     | <\*>                              | `andMap :: f (a -> b) -> f a -> f b`                                                 |


### PR DESCRIPTION
It does exist!

protip: you can search function type signatures at https://hoogle.haskell.org

 e.g. https://hoogle.haskell.org/?hoogle=(a%20-%3E%20b)%20-%3E%20(b%20-%3E%20c)%20-%3E%20a%20-%3E%20c